### PR TITLE
Updates pkg dependancy versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,15 +25,15 @@
   "homepage": "https://github.com/poegroup/poe-ui-builder",
   "dependencies": {
     "component-github-content-api": "^0.1.2",
-    "stylus": "^0.49.0",
-    "nib": "^1.0.2",
-    "component-builder": "^1.1.5",
-    "jade": "^1.3.1",
-    "component-resolver": "^1.1.3",
-    "remotes": "^1.1.6",
+    "stylus": "^0.49.2",
+    "nib": "^1.0.4",
+    "component-builder": "^1.1.13",
+    "jade": "^1.7.0",
+    "component-resolver": "^1.2.4",
+    "remotes": "^1.1.5",
     "mkdirp": "^0.5.0",
     "glob": "^4.0.0",
-    "minimatch": "^0.3.0",
+    "minimatch": "^1.0.0",
     "utils-merge": "^1.0.0"
   }
 }


### PR DESCRIPTION
- _component-builder_ from 1.1.5 to 1.1.13
- _component-resolver_ from 1.1.3 to 1.2.4
- _glob_ from 4.0.0 to  4.0.6
- _jade_ from 1.3.1 to 1.7.0
- _minimatch_ from 0.3.0 to 1.0.0
- _nib_ from 1.0.2 to 1.0.4
- _remotes_ from 1.1.6 to 1.1.5 (npm package not yet updated)
- _stylus_ from 0.49.0 to 0.49.2
